### PR TITLE
Feat(backend): add editor preview endpoints and enable S3 integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ RUN pip install --no-cache-dir --upgrade pip \
 COPY app ./app
 
 # 6) uvicorn 실행 (컨테이너 포트는 8000 가정)
-# ENV APP_ENV=dev
-# EXPOSE 8000
-# CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENV APP_ENV=dev
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter
 
 from .storage.routes import upload_router
+from app.router.editor_router import editor_router
 
 api_router = APIRouter(prefix="/api")
 api_router.include_router(upload_router)
+api_router.include_router(editor_router, prefix="/editor", tags=["editor"])

--- a/app/router/editor_router.py
+++ b/app/router/editor_router.py
@@ -1,0 +1,87 @@
+# backend/app/router/editor_router.py
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional, Literal, Dict
+from datetime import datetime
+from uuid import uuid4
+import os
+
+PreviewStatus = Literal["pending", "processing", "completed", "failed"]
+
+class PreviewCreateBody(BaseModel):
+    text: str
+
+class PreviewRecord(BaseModel):
+    id: str
+    project_id: str
+    language_code: str
+    segment_id: str
+    status: PreviewStatus
+    video_url: Optional[str] = None
+    audio_url: Optional[str] = None
+    updated_at: str
+
+class PreviewGetResponse(BaseModel):
+    status: PreviewStatus
+    videoUrl: Optional[str] = None
+    audioUrl: Optional[str] = None
+    updatedAt: Optional[str] = None
+
+class PreviewCreateResponse(BaseModel):
+    previewId: Optional[str] = None
+    status: PreviewStatus
+    videoUrl: Optional[str] = None
+    audioUrl: Optional[str] = None
+    updatedAt: Optional[str] = None
+
+editor_router = APIRouter()
+
+# 아주 단순한 인메모리 저장 (실서버에서는 Redis/DB 권장)
+PREVIEWS: Dict[str, PreviewRecord] = {}
+
+def now_iso() -> str:
+    return datetime.utcnow().isoformat() + "Z"
+
+def sample_urls():
+    # 환경변수 있으면 우선 사용 (예: presigned GET)
+    v = os.getenv("SAMPLE_VIDEO_URL") or "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+    a = os.getenv("SAMPLE_AUDIO_URL") or "https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3"
+    return v, a
+
+@editor_router.post(
+    "/projects/{project_id}/languages/{lang_code}/segments/{segment_id}/preview",
+    response_model=PreviewCreateResponse,
+)
+async def create_segment_preview(project_id: str, lang_code: str, segment_id: str, body: PreviewCreateBody):
+    # 워커 미구현: 즉시 완료로 응답 (나중에 processing + queue 로 교체)
+    video_url, audio_url = sample_urls()
+    rec = PreviewRecord(
+        id=str(uuid4()),
+        project_id=project_id,
+        language_code=lang_code,
+        segment_id=segment_id,
+        status="completed",
+        video_url=video_url,
+        audio_url=audio_url,
+        updated_at=now_iso(),
+    )
+    PREVIEWS[rec.id] = rec
+    return PreviewCreateResponse(
+        previewId=rec.id,
+        status=rec.status,
+        videoUrl=rec.video_url,
+        audioUrl=rec.audio_url,
+        updatedAt=rec.updated_at,
+    )
+
+@editor_router.get("/preview/{preview_id}", response_model=PreviewGetResponse)
+async def get_preview(preview_id: str):
+    rec = PREVIEWS.get(preview_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="preview not found")
+    return PreviewGetResponse(
+        status=rec.status,
+        videoUrl=rec.video_url,
+        audioUrl=rec.audio_url,
+        updatedAt=rec.updated_at,
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
     depends_on:
       - mongo
     restart: unless-stopped
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    environment:
+      - AWS_PROFILE=dev                # ← 명시 추천 (s3.py가 기본 dev지만 헷갈림 방지)
+      - AWS_REGION=ap-northeast-2      # ← 지역 고정
+      - MONGO_URL_DEV=${MONGO_URL_DEV} 
+    volumes:
+      - ./app:/app/app
+      - "${USERPROFILE}\\.aws:/root/.aws:ro"
 
   mongo:
     image: mongo:7


### PR DESCRIPTION
## 변경사항 요약

미리보기용 에디터 라우터 추가/보강, Docker 구성과 AWS 자격증명 사용 준비, Mongo 서비스 포함

※ 주의 ※
AWS 자격증명 안하면 빌드 실패

- `app/router/editor_router.py` (핵심)
    - **미리보기 생성 API(POST), 상태 조회 API(GET) 추가**

## 코드 수정 사항


### `app/api/main.py`

```py
from fastapi import APIRouter
from .storage.routes import upload_router
from app.router.editor_router import editor_router

api_router = APIRouter(prefix="/api")
api_router.include_router(upload_router)
api_router.include_router(editor_router, prefix="/editor", tags=["editor"])
```

* API 네임스페이스를 `/api`로 잡고, 업로드/에디터 라우터를 하위에 붙인다
* 실제 앱 생성(`FastAPI(app)`)과 마운트는 `app/main.py` 등 상위에서 수행

### `app/router/editor_router.py`

미리보기 생성/조회 **샘플 구현**(인메모리 저장).

* 모델

  * `PreviewCreateBody(text: str)` – 프리뷰 입력 텍스트
  * `PreviewRecord` – 내부 저장 레코드(상태/URL/업데이트 시각)
  * `PreviewCreateResponse`, `PreviewGetResponse` – 프론트 응답 스키마(필드명 `videoUrl/audioUrl/updatedAt`로 프론트와 일치)

* 엔드포인트

  1. `POST /api/editor/projects/{project_id}/languages/{lang_code}/segments/{segment_id}/preview`

     * 지금은 **워커 미구현**이므로 **즉시 `completed`**와 함께 샘플 URL(꽃 영상/티렉스 소리) 반환
     * 나중엔 `processing`으로 저장 → SQS/워커 완료 시 `completed`로 갱신하는 구조로 바꾸면 됨
     * `SAMPLE_VIDEO_URL`, `SAMPLE_AUDIO_URL` 환경변수 있으면 그걸 사용
  2. `GET /api/editor/preview/{preview_id}`

     * 인메모리 `PREVIEWS`에서 상태/URL 반환. 없으면 404