### PR TITLE
Feat: CORS 경로 수정

### DIFF
--- a/app/config/env.py
+++ b/app/config/env.py
@@ -2,4 +2,5 @@ import os
 from dotenv import load_dotenv
 
 load_dotenv()
-origins = os.getenv("CORS_ORIGINS", "http://localhost:5173")
+_raw_origins = os.getenv("CORS_ORIGINS", "http://localhost:5173")
+origins = [origin.strip() for origin in _raw_origins.split(",") if origin.strip()]

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.middleware.middleware import LoggingMiddleware
-from app.config.env_config import origins
+from app.config.env import origins as allowed_origins
 from app.api.deps import DbDep
 from app.config.lifespan import lifespan
 from app.api.main import api_router
@@ -14,12 +14,9 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# 2. CORS 미들웨어 설정 (React 앱의 요청을 허용)
-origins = [origins]
-
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,  # 이 origin들의 요청을 허용
+    allow_origins=allowed_origins,  # 이 origin들의 요청을 허용
     allow_credentials=True,  # 인증 토큰(JWT) 등을 포함한 요청 허용
     allow_methods=["*"],  # 모든 HTTP 메서드 허용
     allow_headers=["*"],  # 모든 HTTP 헤더 허용


### PR DESCRIPTION
## 문제 원인

- `backend/app/config/env.py` (line 5)에서 CORS_ORIGINS를 리스트로 변환하지 않고 문자열 그대로 사용해 허용 Origin이 `["http://localhost:5173,http://127.0.0.1:5173"]` 한 항목으로 처리됨
- `backend/app/main.py` (line 3)에서 이미 문자열인 값을 다시 리스트로 감싸 FastAPI CORS 미들웨어가 실제 Origin(`http://localhost:5173` 등)과 매칭하지 못했고, 프리플라이트 OPTIONS 요청이 400으로 거절됨

## 수정 사항

- `backend/app/config/env.py` (line 5)에서 환경 변수 값을 `split(",")` 후 `strip()`으로 정리해 빈값을 제거한 리스트로 변환
- `backend/app/main.py` (line 3)에서 변환된 리스트를 `allowed_origins` 이름으로 받아 그대로 `allow_origins`에 전달해 CORS가 정확한 `Origin`과 매칭되도록 수정